### PR TITLE
Upgrade ejs-webpack-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-# ejs-webpack-loader for webpack 4.x
+# @code-dot-org/ejs-webpack-loader for webpack 4.x
 
 EJS loader for [webpack](http://webpack.github.io/). Uses [ejs](https://github.com/mde/ejs) function to compile templates.
 
+## Fork
+
+This is a fork of [rorkflash/ejs-webpack-loader](https://github.com/rorkflash/ejs-webpack-loader) and includes the 
+following changes to mitigate some transitive vulnerabilities:
+
+* bump ejs to 3.x
+* bump loader-utils to 2.x
+
 ## Installation
 
-`npm install ejs-webpack-loader`
+`npm install @code-dot-org/ejs-webpack-loader`
 
 ## Config Setup examples as module loader
 
@@ -38,7 +46,7 @@ const config = {
           test: /\.ejs$/,
           use: [
               {
-                loader: "ejs-webpack-loader",
+                loader: "@code-dot-org/ejs-webpack-loader",
                 options: {
                   data: {title: "New Title", someVar:"hello world"},
                   htmlmin: true
@@ -83,7 +91,7 @@ const config = {
                       loader: 'extract-loader'
                   },
                   {
-                      loader: "ejs-webpack-loader",
+                      loader: "@code-dot-org/ejs-webpack-loader",
                       {
                         data: {title: "New Title", someVar:"hello world"},
                         htmlmin: true
@@ -112,7 +120,7 @@ const config = {
   },
   plugin: {
     new HtmlWebpackPlugin({
-        template: '!!ejs-webpack-loader!src/index.ejs'
+        template: '!!@code-dot-org/ejs-webpack-loader!src/index.ejs'
     })
   }
 };

--- a/index.js
+++ b/index.js
@@ -8,10 +8,8 @@ var ejs = require('ejs'),
 
 module.exports = function(source) {
   this.cacheable && this.cacheable();
-  var query = typeof this.query === 'object' ? this.query : utils.parseQuery(this.query);
-  var _options = typeof this.options === 'object' ? this.options['ejs-compiled-loader'] || {} : {};
-  _options = typeof utils.getOptions === 'function' ? merge(utils.getOptions(this), _options) : _options;
-  var opts = merge(_options, query);
+  var opts = typeof this.options === 'object' ? this.options['ejs-compiled-loader'] || {} : {};
+  opts = typeof utils.getOptions === 'function' ? merge(utils.getOptions(this), opts) : opts;
 
   if (opts.client == undefined) {
     opts.client = true;

--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ module.exports = function(source) {
   }
 
   var template = ejs.compile(source, opts);
-  template.dependencies.forEach(this.dependency.bind(this));
 
   // Beautify javascript code
   if (this.loaders.length > 1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ejs-webpack-loader",
-  "version": "2.2.2",
+  "name": "@code-dot-org/ejs-webpack-loader",
+  "version": "3.0.0",
   "description": "EJS webpack 4.x loader (without frontend dependencies)",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/rorkflash/ejs-webpack-loader"
+    "url": "https://github.com/code-dot-org/ejs-webpack-loader"
   },
   "keywords": [
     "ejs",
@@ -19,9 +19,9 @@
   "author": "Ashot Gasparyan <rorkflash@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/rorkflash/ejs-webpack-loader/issues"
+    "url": "https://github.com/code-dot-org/ejs-webpack-loader/issues"
   },
-  "homepage": "https://github.com/rorkflash/ejs-webpack-loader",
+  "homepage": "https://github.com/code-dot-org/ejs-webpack-loader",
   "dependencies": {
     "html-minifier": "^3",
     "loader-utils": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/code-dot-org/ejs-webpack-loader",
   "dependencies": {
     "html-minifier": "^3",
-    "loader-utils": "^0.2.7",
+    "loader-utils": "^2.0.4",
     "merge": "^2.1.1",
     "uglify-js": "~2.6.1"
   },
@@ -33,6 +33,6 @@
     "webpack": "^4.5.0"
   },
   "peerDependencies": {
-    "ejs": "^2.0.0"
+    "ejs": "^3.1.10"
   }
 }


### PR DESCRIPTION
This PR bumps transitive dependencies for ejs-webpack-loader:

* ejs from 2.0.0 to 3.1.10
* loader-utils from 0.2.7 to 2.0.4